### PR TITLE
fusclient: fix 403 Client Error: Forbidden for recent devices

### DIFF
--- a/samloader/fusclient.py
+++ b/samloader/fusclient.py
@@ -37,7 +37,7 @@ class FUSClient:
         headers = {"Authorization": authv, "User-Agent": "Kies2.0_FUS"}
         if start > 0:
             headers["Range"] = "bytes={}-".format(start)
-        req = requests.get("http://cloud-neofussvr.sslcs.cdngc.net/NF_DownloadBinaryForMass.do",
+        req = requests.get("http://cloud-neofussvr.samsungmobile.com/NF_DownloadBinaryForMass.do",
                            params="file=" + filename, headers=headers, stream=True)
         req.raise_for_status()
         return req


### PR DESCRIPTION
On at least SM-S908B we get the following error trying to download a FW file:

```
$ samloader -m SM-S908B -r BTB download -v S908BXXS6CWH6/S908BOXM6CWH5/S908BXXU6CWH5/S908BXXS6CWH6 -O .
downloading SM-S908B_2_20230919175350_ua1z7hsbay_fac.zip.enc4
Traceback (most recent call last):
  File "/usr/sbin/samloader", line 33, in <module>
    sys.exit(load_entry_point('samloader==0.4', 'console_scripts', 'samloader')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/samloader/main.py", line 51, in main
    r = client.downloadfile(path+filename, dloffset)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/samloader/fusclient.py", line 42, in downloadfile
    req.raise_for_status()
  File "/usr/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: http://cloud-neofussvr.sslcs.cdngc.net/NF_DownloadBinaryForMass.do?file=/neofus/910/SM-S908B_2_20230919175350_ua1z7hsbay_fac.zip.enc4
```

Fix by changing download url. Patch has been adapted from https://github.com/ananjaser1211/SamloaderKotlin/commit/8a0d50428ac7080f9c2cbe8847da06bbccb20798.